### PR TITLE
Add unit declarator to module and class declarations

### DIFF
--- a/lib/SP6.pm6
+++ b/lib/SP6.pm6
@@ -1,4 +1,4 @@
-class SP6;
+unit class SP6;
 
 has $.templ_dir;
 has $.debug;

--- a/lib/SP6/ProcessMethods.pm6
+++ b/lib/SP6/ProcessMethods.pm6
@@ -1,4 +1,4 @@
-module SP6::ProcessMethods;
+unit module SP6::ProcessMethods;
 
 multi sub esc(*@argv) is export {
 	# todo


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
